### PR TITLE
Add MANIFEST_BRANCH opt.

### DIFF
--- a/.github/workflows/recovery.yml
+++ b/.github/workflows/recovery.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   MANIFEST: https://gitlab.com/OrangeFox/Manifest.git
+  MANIFEST_BRANCH: fox_9.0
   DEVICE: rosy
   DT_LINK: https://github.com/ElytrA8/recovery_rosy
   DT_PATH: device/xiaomi/rosy
@@ -48,7 +49,7 @@ jobs:
          run: |
              mkdir work
              cd work
-             repo init -u $MANIFEST --depth=1 --groups=all,-notdefault,-device,-darwin,-x86,-mips
+             repo init -u $MANIFEST -b $MANIFEST_BRANCH --depth=1 --groups=all,-notdefault,-device,-darwin,-x86,-mips
              repo sync -j4
              git clone $DT_LINK --depth=1 --single-branch $DT_PATH
              

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Some variables that you'd like to set:
 
 ```MANIFEST : Link to your recovery manifest, Google it if you don't know what this is```
 
+```MANIFEST_BRANCH : Branch of your recovery manifest. Again, Google it if you don't know what this is```
+
 ```DEVICE : Most likely your device codename, e.g. rosy, sakura, curtana, etc.```
 
 ```DT_LINK : Link to your recovery device tree.```


### PR DESCRIPTION
Useful for those recoveries having more than 1 buildable branch, eg for Q/P recoveries.